### PR TITLE
sy/input_encode_entities

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for HTML-FormBuilder
 
+0.11  2015-12-10
+        - encode / decode HTML entities in get / set field
+
 0.10  2015-10-12
         - allow <input>, heading /traling text to be wrapped in <div>, for better checkbox styling
         - Add no_new_line option for comment only field

--- a/lib/HTML/FormBuilder.pm
+++ b/lib/HTML/FormBuilder.pm
@@ -260,7 +260,7 @@ sub set_field_value {
                 # for select box
                 $_->value($field_value);
             } elsif ($_->{'type'} =~ /(?:text|textarea|password|hidden|file)/i) {
-                $_->{'value'} = $field_value;
+                $_->{'value'} = HTML::Entities::encode_entities($field_value // '');
             } elsif ($_->{'type'} eq 'checkbox') {
                 # if value not set during $fieldset->add_field(), default to browser default value for checkbox: 'on'
                 my $checkbox_value = $_->{'value'} // 'on';
@@ -293,9 +293,10 @@ sub get_field_value {
                 return $input->value;
             }
             return unless $input->{type};
-            if (   $input->{type} =~ /(?:text|textarea|password|hidden|file)/i
-                || $input->{type} eq 'checkbox' && $input->{checked} && $input->{checked} eq 'checked')
-            {
+
+            if ($input->{type} =~ /(?:text|textarea|password|hidden|file)/i) {
+                return HTML::Entities::decode_entities($input->{value} // '');
+            } elsif ($input->{type} eq 'checkbox' && $input->{checked} && $input->{checked} eq 'checked') {
                 # if value not set during $fieldset->add_field(), default to browser default value for checkbox: 'on'
                 return ($input->{value} // 'on');
             }

--- a/lib/HTML/FormBuilder.pm
+++ b/lib/HTML/FormBuilder.pm
@@ -3,7 +3,7 @@ package HTML::FormBuilder;
 use strict;
 use warnings;
 use 5.008_005;
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 
 use Carp;
 use HTML::FormBuilder::FieldSet;

--- a/lib/HTML/FormBuilder.pm
+++ b/lib/HTML/FormBuilder.pm
@@ -10,6 +10,7 @@ use HTML::FormBuilder::FieldSet;
 use String::Random ();
 use Moo;
 use namespace::clean;
+use HTML::Entities;
 extends qw(HTML::FormBuilder::Base);
 
 has data => (

--- a/lib/HTML/FormBuilder/Base.pm
+++ b/lib/HTML/FormBuilder/Base.pm
@@ -3,7 +3,7 @@ package HTML::FormBuilder::Base;
 use strict;
 use warnings;
 use 5.008_005;
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 
 use Carp;
 use Moo;

--- a/lib/HTML/FormBuilder/Base.pm
+++ b/lib/HTML/FormBuilder/Base.pm
@@ -130,6 +130,12 @@ please refer to L<HTML::FormBuilder>.
 
 Chylli L<chylli@binary.com>
 
+=head1 CONTRIBUTOR
+
+Fayland Lam L<fayland@binary.com>
+
+Tee Shuwn Yuan L<shuwnyuan@binary.com>
+
 =head1 COPYRIGHT AND LICENSE
 
 =cut

--- a/lib/HTML/FormBuilder/Field.pm
+++ b/lib/HTML/FormBuilder/Field.pm
@@ -3,7 +3,7 @@ package HTML::FormBuilder::Field;
 use strict;
 use warnings;
 use 5.008_005;
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 
 use Carp;
 use Scalar::Util qw(weaken blessed);

--- a/lib/HTML/FormBuilder/FieldSet.pm
+++ b/lib/HTML/FormBuilder/FieldSet.pm
@@ -216,6 +216,12 @@ append fields into fieldset and return the number of fields added.
 
 Chylli L<chylli@binary.com>
 
+=head1 CONTRIBUTOR
+
+Fayland Lam L<fayland@binary.com>
+
+Tee Shuwn Yuan L<shuwnyuan@binary.com>
+
 =head1 COPYRIGHT AND LICENSE
 
 =cut

--- a/lib/HTML/FormBuilder/FieldSet.pm
+++ b/lib/HTML/FormBuilder/FieldSet.pm
@@ -3,7 +3,7 @@ package HTML::FormBuilder::FieldSet;
 use strict;
 use warnings;
 use 5.008_005;
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 
 use HTML::FormBuilder::Field;
 use Carp;

--- a/lib/HTML/FormBuilder/Select.pm
+++ b/lib/HTML/FormBuilder/Select.pm
@@ -2,7 +2,7 @@ package HTML::FormBuilder::Select;
 use strict;
 use warnings;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 
 use Carp;
 use Moo;

--- a/lib/HTML/FormBuilder/Validation.pm
+++ b/lib/HTML/FormBuilder/Validation.pm
@@ -2,7 +2,7 @@ package HTML::FormBuilder::Validation;
 
 use strict;
 use warnings;
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 
 use Carp;
 use Class::Std::Utils;


### PR DESCRIPTION
properly encode / decode HTML entities for form input, to eliminate HTML attribute injection.
This is needed as we now allow broader range of char for password, it may contains " ' < > (any printable char from "SPACE" to '~' in ASCII table)
